### PR TITLE
match source files with optional regex on command line

### DIFF
--- a/src/Source/SourceDirectoryScanner.php
+++ b/src/Source/SourceDirectoryScanner.php
@@ -19,11 +19,12 @@ class SourceDirectoryScanner
     /**
      * @param TombstoneExtractor $tombstoneExtractor
      * @param string $sourcePath
+     * @param array $regularExpressions Match source files against passed patterns. Defaults to ['*.php']
      */
-    public function __construct(TombstoneExtractor $tombstoneExtractor, $sourcePath)
+    public function __construct(TombstoneExtractor $tombstoneExtractor, $sourcePath, $regularExpressions = array('*.php'))
     {
         $this->tombstoneExtractor = $tombstoneExtractor;
-        $finder = new FinderFacade(array($sourcePath), array(), array('*.php'));
+        $finder = new FinderFacade(array($sourcePath), array(), $regularExpressions);
         $this->files = $finder->findFiles();
     }
 


### PR DESCRIPTION
Tombstones located in files other than *.php aren't found (*.phtml for example). You can now specify on the command line what are the patterns for your sources.

    bin/tombstone  -m "*.php" -m "*.phtml" -m"*.whatever" source_dir log_dir

Feel free to request different naming / documentation.

btw, tombstone helped us kill nearly 100kLOC of legacy dead code, many thanks for this 🎆 