### PR TITLE
updated treebuilder root node usage

### DIFF
--- a/src/Config/Configuration.php
+++ b/src/Config/Configuration.php
@@ -14,8 +14,8 @@ class Configuration implements ConfigurationInterface
 
     public function getConfigTreeBuilder()
     {
-        $treeBuilder = new TreeBuilder(self::CONFIG_ROOT);
-        $rootNode = $treeBuilder->getRootNode();
+        $treeBuilder = new TreeBuilder();
+        $rootNode = $treeBuilder->root(self::CONFIG_ROOT);
 
         /* @var ArrayNodeDefinition $rootNode */
         $rootNode


### PR DESCRIPTION
replaced deprecated call in for rootNodes in config with current one from symfony 4.2.0 