### PR TITLE
Root config entry is not optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ source:
     notNames:
         - "*.js"
 
-# Optional, the root directory is used to make paths from the scanned sources relative. This is important, if you made
+# The root directory is used to make paths from the scanned sources relative. This is important, if you made
 # the paths in your logs relative to a root directory.
 rootDir: root
 


### PR DESCRIPTION
Its stated in the Readme file, that the `root` configuration entry is optional. However, if executing the binary without this in the config, the code fails.